### PR TITLE
Made zip archive output into a single directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.1.0 - 2024-03-05
+- Changes the zippedOut output into a zipped directory. This ensures that extraction creates a new directory instead of tarbombing the working directory.
 ## 1.0.0 - 2024-03-04
 - Completes lane level alignments using Dragen
 - Supports whole transcriptome alignment

--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Output | Type | Description
      --enable-duplicate-marking false \
      ~{if (isRNA) then "--enable-rna true" else ""}
      
-     zip -m ~{zipFileName} $(ls | grep '~{prefix}.*.csv\|~{prefix}.*.tab' | tr '\n' ' ')
+     mkdir ~{zipFileName}
+     cp -t ~{zipFileName} $(ls | grep '~{prefix}.*.csv\|~{prefix}.*.tab' | tr '\n' ' ')
+     zip -r ~{zipFileName}.zip ~{zipFileName}
  ```
  ## Support
 

--- a/commands.txt
+++ b/commands.txt
@@ -65,5 +65,7 @@ This section lists command(s) run by dragenAlign workflow
     --enable-duplicate-marking false \
     ~{if (isRNA) then "--enable-rna true" else ""}
     
-    zip -m ~{zipFileName} $(ls | grep '~{prefix}.*.csv\|~{prefix}.*.tab' | tr '\n' ' ')
+    mkdir ~{zipFileName}
+    cp -t ~{zipFileName} $(ls | grep '~{prefix}.*.csv\|~{prefix}.*.tab' | tr '\n' ' ')
+    zip -r ~{zipFileName}.zip ~{zipFileName}
 ```

--- a/dragenAlign.wdl
+++ b/dragenAlign.wdl
@@ -164,7 +164,7 @@ task runDragen {
   # Boolean indicating whether to enable transcriptomic analysis
   Boolean isRNA = if mode == "transcriptome" then true else false
   
-  String zipFileName = "~{prefix}_alignment_outputs.zip"
+  String zipFileName = "~{prefix}_additional_outputs"
 
   command <<<
     set -euo pipefail
@@ -187,7 +187,9 @@ task runDragen {
     --enable-duplicate-marking false \
     ~{if (isRNA) then "--enable-rna true" else ""}
     
-    zip -m ~{zipFileName} $(ls | grep '~{prefix}.*.csv\|~{prefix}.*.tab' | tr '\n' ' ')
+    mkdir ~{zipFileName}
+    cp -t ~{zipFileName} $(ls | grep '~{prefix}.*.csv\|~{prefix}.*.tab' | tr '\n' ' ')
+    zip -r ~{zipFileName}.zip ~{zipFileName}
   >>>
 
   runtime {
@@ -198,7 +200,7 @@ task runDragen {
   output {
     File bam = "~{prefix}.bam"
     File bamIndex = "~{prefix}.bam.bai"
-    File zippedOut = "~{zipFileName}"
+    File zippedOut = "~{zipFileName}.zip"
     File? outputChimeric = "~{prefix}.Chimeric.out.junction"
   }
 

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -81,7 +81,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.0.0/output_metrics/PCSI0022C_notrim_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.1.0/output_metrics/PCSI0022C_notrim_bam.metrics",
                 "type": "script"
             }
         ]
@@ -168,7 +168,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.0.0/output_metrics/PCSI0022C_trim_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.1.0/output_metrics/PCSI0022C_trim_bam.metrics",
                 "type": "script"
             }
         ]
@@ -244,7 +244,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.0.0/output_metrics/PCSI0022C_trim_bam_se.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.1.0/output_metrics/PCSI0022C_trim_bam_se.metrics",
                 "type": "script"
             }
         ]
@@ -320,7 +320,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.0.0/output_metrics/PCSI0022C_notrim_bam_se.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.1.0/output_metrics/PCSI0022C_notrim_bam_se.metrics",
                 "type": "script"
             }
         ]
@@ -407,7 +407,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.0.0/output_metrics/K562_notrim_wt_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.1.0/output_metrics/K562_notrim_wt_bam.metrics",
                 "type": "script"
             }
         ]
@@ -494,7 +494,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.0.0/output_metrics/K562_trim_wt_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.1.0/output_metrics/K562_trim_wt_bam.metrics",
                 "type": "script"
             }
         ]
@@ -570,7 +570,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.0.0/output_metrics/K562_notrim_wt_bam_se.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.1.0/output_metrics/K562_notrim_wt_bam_se.metrics",
                 "type": "script"
             }
         ]
@@ -657,7 +657,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.0.0/output_metrics/EPT105_A_notrim_wt_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.1.0/output_metrics/EPT105_A_notrim_wt_bam.metrics",
                 "type": "script"
             }
         ]
@@ -733,7 +733,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.0.0/output_metrics/EPT105_B_trim_wt_bam_se.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragenAlign/1.1.0/output_metrics/EPT105_B_trim_wt_bam_se.metrics",
                 "type": "script"
             }
         ]


### PR DESCRIPTION
Modified the runDragen task such that the zip archive is a single directory, and extraction creates a new directory instead of tarbombing the working directory with multiple files. 

Making this modification based on the WDL Best Practices:
https://wiki.oicr.on.ca/display/GSI/WDL+Best+Practices