### PR TITLE
Added names to vidarrbuild.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.2.1 - 2024-04-04
+- Changed names in vidarrbuild.json
 ## 1.2.0 - 2024-03-26
 - Workflow requires an array of fastq files with read-groups as input. A single fastq-pair (or a single fastq file) must also be inputted as an array. 
 - runDragen task outputs a merged bam file

--- a/vidarrbuild.json
+++ b/vidarrbuild.json
@@ -1,6 +1,8 @@
 {
     "names": [
-        "dragenAlign"
+        "dragenAlign_WG_lane_level",
+        "dragenAlign_WT_call_ready",
+        "dragenAlign_WT_lane_level"
     ],
     "wdl": "dragenAlign.wdl"
 }


### PR DESCRIPTION
Since this workflow can do WG lane-level and WT lane-level/call-ready, we have to add multiple names in Vidarr for the workflow. 